### PR TITLE
Add support for 'open options'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(GDAL_SRC)/build/Makefile: $(ROOT_DIR)/lib/libsqlite3.a $(ROOT_DIR)/lib/libproj
 	cd build; \
 	$(EMCMAKE) cmake .. $(PREFIX_CMAKE) -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_APPS=OFF \
         -DCMAKE_PREFIX_PATH=$(ROOT_DIR) -DCMAKE_FIND_ROOT_PATH=$(ROOT_DIR) \
-        -DGDAL_USE_HDF5=OFF GDAL_USE_HDFS=OFF \
+        -DGDAL_USE_HDF5=OFF -DGDAL_USE_HDFS=OFF \
         -DSQLite3_INCLUDE_DIR=$(ROOT_DIR)/include -DSQLite3_LIBRARY=$(ROOT_DIR)/lib/libsqlite3.a \
         -DPROJ_INCLUDE_DIR=$(ROOT_DIR)/include -DPROJ_LIBRARY_RELEASE=$(ROOT_DIR)/lib/libproj.a \
         -DTIFF_INCLUDE_DIR=$(ROOT_DIR)/include -DTIFF_LIBRARY_RELEASE=$(ROOT_DIR)/lib/libtiff.a \

--- a/src/allCFunctions.js
+++ b/src/allCFunctions.js
@@ -9,7 +9,13 @@ export function initCFunctions() {
     Module.ccall('GDALAllRegister', null, [], []);
 
     GDALFunctions.GDALOpen = Module.cwrap('GDALOpen', 'number', ['string']);
-    GDALFunctions.GDALOpenEx = Module.cwrap('GDALOpenEx', 'number', ['string']);
+    GDALFunctions.GDALOpenEx = Module.cwrap('GDALOpenEx', 'number', [
+        'string', // char * the destination dataset path or NULL.
+        'number', // unsigned int a combination of GDAL_OF_ flags that may be combined through logical or operator.
+        'number', // char ** null-terminated array of strings with the driver short names that must be considered.
+        'number', // char ** null-terminated array of strings with the dataset open options.
+        'number', // char ** null-terminated array of strings that are filenames auxiliary to the main filename.
+    ]);
     GDALFunctions.GDALClose = Module.cwrap('GDALClose', null, ['number']);
     GDALFunctions.CPLErrorReset = Module.cwrap('CPLErrorReset', null, []);
     GDALFunctions.CPLSetErrorHandler = Module.cwrap('CPLSetErrorHandler', 'number', ['number']);

--- a/test/data/pts.csv
+++ b/test/data/pts.csv
@@ -1,0 +1,3 @@
+city,country,lat,lng
+Tokyo,Japan,35.6897,139.6922
+Jakarta,Indonesia,-6.2146,106.8451


### PR DESCRIPTION
This PR add support for the dataset open options (which are format-specific and usually used behind the `-oo` parameter when using *ogr2ogr*, *ogrinfo*, *gdalinfo*, etc.) in order to fix #41.

The options must be given in the 2nd (optional) argument of `Gdal.open`, in a list of strings, like the following:

```js
// Without options as before
const input = await Gdal.open(file);
// With option
const input = await Gdal.open(file, ['X_POSSIBLE_NAMES=lng', 'Y_POSSIBLE_NAMES=lat']);
```

I also added a test case using the open options of the CSV driver.