### PR TITLE
Add gdal location info

### DIFF
--- a/GDAL_EMCC_FLAGS.mk
+++ b/GDAL_EMCC_FLAGS.mk
@@ -96,8 +96,13 @@ GDAL_EMCC_FLAGS += -s EXPORTED_FUNCTIONS="[\
   '_GDALCreateGenImgProjTransformer2',\
   '_GDALDestroyGenImgProjTransformer',\
   '_OSRSetFromUserInput',\
+  '_OSRExportToWkt',\
   '_CPLSetConfigOption',\
-  '_CPLSetThreadLocalConfigOption'\
+  '_CPLSetThreadLocalConfigOption',\
+  '_GDALGetSpatialRef',\
+  '_CPLAtof',\
+  '_OSRSetAxisMappingStrategy',\
+  '_GDALInvGeoTransform'\
 ]"
 
 GDAL_EMCC_FLAGS += -s EXPORTED_RUNTIME_METHODS="[\

--- a/src/allCFunctions.js
+++ b/src/allCFunctions.js
@@ -31,6 +31,7 @@ export function initCFunctions() {
     GDALFunctions.GDALGetRasterYSize = Module.cwrap('GDALGetRasterYSize', 'number', ['number']);
     GDALFunctions.GDALGetProjectionRef = Module.cwrap('GDALGetProjectionRef', 'string', ['number']);
     GDALFunctions.GDALGetGeoTransform = Module.cwrap('GDALGetGeoTransform', 'number', ['number', 'number']);
+    GDALFunctions.GDALInvGeoTransform = Module.cwrap('GDALInvGeoTransform', 'number', ['number', 'number']);
     GDALFunctions.GDALVectorTranslate = Module.cwrap('GDALVectorTranslate', 'number', [
         'string', // char * the destination dataset path or NULL.
         'number', // GDALDatasetH the destination dataset or NULL.
@@ -119,6 +120,9 @@ export function initCFunctions() {
     GDALFunctions.GDALDestroyGenImgProjTransformer = Module.cwrap('GDALDestroyGenImgProjTransformer', null, ['number']);
 
     GDALFunctions.OSRSetFromUserInput = Module.cwrap('OSRSetFromUserInput', 'number', ['number', 'string']);
-
+    GDALFunctions.OSRExportToWkt = Module.cwrap('OSRExportToWkt', 'number',['number','number']);
+    GDALFunctions.GDALGetSpatialRef = Module.cwrap('GDALGetSpatialRef','number',['number'])
+    GDALFunctions.CPLAtof = Module.cwrap('CPLAtof','number',['string'])
+    GDALFunctions.OSRSetAxisMappingStrategy = Module.cwrap('OSRSetAxisMappingStrategy',null,['number','number'])
     // GDALFunctions.CPLSetErrorHandler(cplQuietFnPtr);
 }

--- a/src/allJsFunctions.js
+++ b/src/allJsFunctions.js
@@ -10,6 +10,7 @@ import close from './allJsFunctions/function/close';
 import getInfo from './allJsFunctions/function/getInfo';
 import getOutputFiles from './allJsFunctions/function/getOutputFiles';
 import getFileBytes from './allJsFunctions/function/getFileBytes';
+import gdal_location_info from './allJsFunctions/application/gdal_location_info'
 
 import { drivers } from './allJsFunctions/helper/drivers';
 
@@ -25,4 +26,5 @@ export default {
     getOutputFiles,
     getFileBytes,
     drivers,
+    gdal_location_info
 };

--- a/src/allJsFunctions/application/gdal_location_info.js
+++ b/src/allJsFunctions/application/gdal_location_info.js
@@ -1,0 +1,94 @@
+/* eslint-disable function-paren-newline */
+/* eslint-disable no-underscore-dangle */
+import { GDALFunctions } from "../../allCFunctions";
+import { getOptions, clearOptions } from "../helper/options";
+
+/**
+ * The gdal location info utility converts a latitude and longitude into a pixel and line in the dataset
+ *
+ * {@link https://gdal.org/programs/gdallocationinfo.html}
+ *
+ * @module a/gdal_location_info
+ * @async
+ * @param {TypeDefs.Dataset} dataset Dataset to be converted.
+ * @param {Array<Array<number>>} coords Coordinates to be converted. Example: [45.5,-108.5] lat/lon -wgs84 ie. this always acts as if -wgs84 was passed to gdalLocationinfo
+ * @return {Promise<Array<Array<number>>>} "Promise" returns converted coordinates.
+ * @example
+ * const coords = [45.5,-108.5];
+ * const pixelCoords = await Gdal.gdal_location_info(dataset,coords);
+ * console.log(pixelCoords); // { "pixel": 3256, "line": 8664 }
+ */
+export default function gdal_location_info(dataset, coords) {
+    return new Promise((resolve,reject) => {
+        const hSrcSRS = GDALFunctions.OSRNewSpatialReference(
+            `GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]]` // WKT for wgs84
+        );
+        
+        GDALFunctions.OSRSetAxisMappingStrategy(hSrcSRS, 0); //TRADITIONAL_GIS_ORDER
+        let hTrgSRS = GDALFunctions.GDALGetSpatialRef(dataset.pointer);
+        let hct = GDALFunctions.OCTNewCoordinateTransformation(
+            hSrcSRS,
+            hTrgSRS
+        );
+
+        let doubleLat = GDALFunctions.CPLAtof(String(coords[0]));
+        let doubleLon = GDALFunctions.CPLAtof(String(coords[1]));
+
+        let latPointer = GDALFunctions.Module._malloc(8); // double
+        GDALFunctions.Module.setValue(latPointer, doubleLat, "double");
+
+        let lonPointer = GDALFunctions.Module._malloc(8); // double
+        GDALFunctions.Module.setValue(lonPointer, doubleLon, "double");
+
+        let success = GDALFunctions.OCTTransform(
+            hct,
+            1,
+            lonPointer,
+            latPointer,
+            null
+        );
+        if(!success){
+            reject("Failed to perform OCTTransform");
+        }
+        let dfGeoX = GDALFunctions.Module.getValue(lonPointer, "double");
+        let dfGeoY = GDALFunctions.Module.getValue(latPointer, "double");
+
+        const geoTransformByteOffset = GDALFunctions.Module._malloc(
+            6 * Float64Array.BYTES_PER_ELEMENT
+        );
+        GDALFunctions.GDALGetGeoTransform(
+            dataset.pointer,
+            geoTransformByteOffset
+        );
+
+        const inverseGeoTransformByteOffset = GDALFunctions.Module._malloc(
+            6 * Float64Array.BYTES_PER_ELEMENT
+        );
+        const successfulInverseTransform = GDALFunctions.GDALInvGeoTransform(
+            geoTransformByteOffset,
+            inverseGeoTransformByteOffset
+        );
+        if(!successfulInverseTransform){
+            reject("Failed to invert transform")
+        }
+        const inverseGeoTransform = GDALFunctions.Module.HEAPF64.subarray(
+            inverseGeoTransformByteOffset / Float64Array.BYTES_PER_ELEMENT,
+            inverseGeoTransformByteOffset / Float64Array.BYTES_PER_ELEMENT + 6
+        );
+        let iPixel = Math.floor(
+            inverseGeoTransform[0] +
+                inverseGeoTransform[1] * dfGeoX +
+                inverseGeoTransform[2] * dfGeoY
+        );
+        let iLine = Math.floor(
+            inverseGeoTransform[3] +
+                inverseGeoTransform[4] * dfGeoX +
+                inverseGeoTransform[5] * dfGeoY
+        );
+
+        resolve({
+            pixel: iPixel,
+            line: iLine,
+        });
+    });
+}

--- a/src/allJsFunctions/application/gdal_location_info.spec.js
+++ b/src/allJsFunctions/application/gdal_location_info.spec.js
@@ -1,0 +1,38 @@
+/* eslint-disable global-require */
+/* eslint-disable func-names */
+const isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]'; // https://github.com/iliakan/detect-node/blob/master/index.js
+
+let Gdal;
+let assert;
+
+if (isNode) assert = require('chai').assert;
+else assert = chai.assert;
+
+describe('application / gdal_location_info', function () {
+    before(async function () {
+        if (isNode) {
+            this.timeout(15000);
+            const dest = require('fs').mkdtempSync('/tmp/gdaljs');
+            const initGdalJs = require('../../../build/package/gdal3.coverage');
+            Gdal = await initGdalJs({ path: 'build/package', dest });
+        } else {
+            this.timeout(30000);
+            Gdal = await initGdalJs({ path: '../package', useWorker: false });
+        }
+    });
+    it('gdal_location_info', async function () {
+        let file = 'data/vfr_wall.tif';
+        if (!isNode) {
+            const fileData = await fetch(file);
+            file = new File([await fileData.blob()], 'vfr_wall.tif');
+        } else file = `test/${file}`;
+
+        const result = await Gdal.open(file);
+        const firstDataset = result.datasets[0];
+        
+        const stLouisAirport = await Gdal.gdal_location_info(firstDataset,[38.7548,-90.3575]);
+        
+        assert.strictEqual(stLouisAirport.pixel === 11511, true, 'An error occurred while converting the coordinates (wrong result, for pixel)');
+        assert.strictEqual(stLouisAirport.line === 5349, true, 'An error occurred while converting the coordinates (wrong result, for line)');
+    });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,6 +39,11 @@ interface DatasetInfo {
     layers?: Array<Layer>;
 }
 
+interface LocationInfo{
+    pixel: number;
+    line: number;
+}
+
 interface Drivers {
     raster: Object;
     vector: Object;
@@ -56,7 +61,7 @@ interface Gdal {
     getOutputFiles(): Promise<Array<FileInfo>>;
     getFileBytes(filePath: string|FilePath): Promise<Uint8Array>;
     drivers: Drivers;
-    gdallocationinfo: Promise<void>; //TODO: Change this
+    gdal_location_info: Promise<LocationInfo>;
 }
 
 interface GdalFilePaths {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,6 +56,7 @@ interface Gdal {
     getOutputFiles(): Promise<Array<FileInfo>>;
     getFileBytes(filePath: string|FilePath): Promise<Uint8Array>;
     drivers: Drivers;
+    gdallocationinfo: Promise<void>; //TODO: Change this
 }
 
 interface GdalFilePaths {


### PR DESCRIPTION
I found myself needing, nearly exactly what [gdal location info](https://gdal.org/programs/gdallocationinfo.html#index-0) does so I've added it in. 

This particular implementation will always act as if you were running `gdallocationinfo -wgs84 <file name> coordLat coordLon`  though I suspect this could be altered relatively easily in the future if the need arises.