### PR TITLE
Support open prefixes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,7 +55,7 @@ interface Gdal {
     gdal_rasterize(dataset: Dataset, options: Array<string>): Promise<FilePath>;
     gdalwarp(dataset: Dataset, options: Array<string>): Promise<FilePath>;
     gdaltransform(coords: Array<Array<number>>, options: Array<string>): Promise<Array<Array<number>>>;
-    open(fileOrFiles: FileList|File|Array<string>|string): Promise<DatasetList>;
+    open(fileOrFiles: FileList|File|Array<string>|string, options?: Array<string>, VFSHandlers?: Array<string>): Promise<DatasetList>;
     close(dataset: Dataset): Promise<void>;
     getInfo(dataset: Dataset): Promise<DatasetInfo>;
     getOutputFiles(): Promise<Array<FileInfo>>;


### PR DESCRIPTION
First of all, thanks for your work maintaining the library 🙇 

We've been struggling to open a zipped shapefile and we thought it would be nice to add support to [Virtual File Systems](https://gdal.org/user/virtual_file_systems.html#network-based-file-systems) to the library. To achieve this we added a third parameter to the `open` function. 

Hoping you are willing to merge this PR, please let us know if you'd like the approach or if you need us to change anything.