### PR TITLE
Support absolute path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,8 +120,9 @@ export default function initGdalJs(
 
             if (isNode) {
                 Module.getPreloadedPackage = function getPreloadedPackage(packageName) {
+                    const path = packageName.startsWith('/') ? packageName : `./${packageName}`;
                     // eslint-disable-next-line global-require
-                    return require('fs').readFileSync(`./${packageName}`, { flag: 'r' }).buffer;
+                    return require('fs').readFileSync(path, { flag: 'r' }).buffer;
                 };
             }
 


### PR DESCRIPTION
Absolute paths are used in Electron applications
e.g: `/tmp/appName/resources/app.asar/node_modules/gdal3.js/dist/package`