### PR TITLE
Fix memory leak by cleaning up promises in worker

### DIFF
--- a/src/workerSupport.js
+++ b/src/workerSupport.js
@@ -47,6 +47,9 @@ class WorkerWrapper {
             if (evt.data && evt.data.id && this.promises[evt.data.id]) {
                 if (evt.data.success) this.promises[evt.data.id].resolve(evt.data.data);
                 else this.promises[evt.data.id].reject(evt.data.data);
+
+                // Fix for memory leak: Clean up the resolved/rejected promise to prevent memory accumulation in the WorkerWrapper
+                delete this.promises[evt.data.id];
             }
         };
         this.gdalWorker.postMessage({ func: 'constructor', params: { config } });


### PR DESCRIPTION
Thank you for providing such an amazing library. I think I've fixed a small issue, so I'm submitting this Pull Request.

## Description
This PR resolves a critical bug within the `WorkerWrapper` class that occur when executing heavy or highly concurrent tasks (e.g., chunked raster tile processing) via the Web Worker.

### Memory Leak Fix in `onmessage` (`this.promises` accumulation)
**Bug:** 
Whenever a worker task was completed and the `onmessage` handler called `resolve()` or `reject()`, the promise object inside `this.promises[evt.data.id]` was never cleaned up. When processing thousands of chunks or large files, this caused a massive JS heap memory leak, eventually crashing the browser tab.

**Fix:** 
Added `delete this.promises[evt.data.id];` immediately after the promise is fulfilled. This allows the garbage collector to properly free the memory.

## Changes Made
- Modified `onmessage` to `delete` the completed promise callback from the dictionary.

## Checklist
- [x] Tested with sequential heavy tiling processes (Memory leak confirmed fixed).