### PR TITLE
feature: add clearFS() API to clear virtual filesystem

### DIFF
--- a/src/allJsFunctions.js
+++ b/src/allJsFunctions.js
@@ -10,6 +10,7 @@ import ogrinfo from './allJsFunctions/application/ogrinfo';
 
 import open from './allJsFunctions/function/open';
 import close from './allJsFunctions/function/close';
+import clearFS from './allJsFunctions/function/clearFS';
 import getInfo from './allJsFunctions/function/getInfo';
 import getOutputFiles from './allJsFunctions/function/getOutputFiles';
 import getFileBytes from './allJsFunctions/function/getFileBytes';
@@ -28,6 +29,7 @@ export default {
     ogrinfo,
     open,
     close,
+    clearFS,
     getInfo,
     getOutputFiles,
     getFileBytes,

--- a/src/allJsFunctions/function/clearFS.js
+++ b/src/allJsFunctions/function/clearFS.js
@@ -1,0 +1,40 @@
+import isNode from 'detect-node';
+import { GDALFunctions } from '../../allCFunctions';
+import { INPUTPATH, OUTPUTPATH } from '../helper/const';
+
+const unlinkDir = (FS, dir) => {
+    FS.readdir(dir)
+        .filter((name) => name !== '.' && name !== '..')
+        .forEach((name) => FS.unlink(`${dir}/${name}`));
+};
+
+/**
+    * Remove all files from the virtual filesystem (/input and /output).
+    * On Node.js, only cleans /output if it is not backed by NODEFS (i.e. config.dest was not set).
+    * In a Web Worker, only /output is cleaned: /input is mounted as WORKERFS which holds only
+    * references to File objects without copying data into memory, and is released via unmount().
+    *
+    * @module f/clearFS
+    * @async
+    * @return {Promise<void>}
+    * @example
+    * await Gdal.clearFS();
+*/
+export default function clearFS() {
+    return new Promise((resolve) => {
+        const { FS } = GDALFunctions.Module;
+
+        if (isNode) {
+            const outputMount = FS.lookupPath(OUTPUTPATH).node.mount.type;
+            if (outputMount !== GDALFunctions.Module.NODEFS) {
+                unlinkDir(FS, OUTPUTPATH);
+            }
+        } else {
+            const isWorker = typeof importScripts === 'function';
+            const paths = isWorker ? [OUTPUTPATH] : [INPUTPATH, OUTPUTPATH];
+            paths.forEach((dir) => unlinkDir(FS, dir));
+        }
+
+        resolve();
+    });
+}

--- a/src/allJsFunctions/function/clearFS.spec.js
+++ b/src/allJsFunctions/function/clearFS.spec.js
@@ -1,0 +1,84 @@
+/* eslint-disable global-require */
+/* eslint-disable func-names */
+const isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]'; // https://github.com/iliakan/detect-node/blob/master/index.js
+
+let Gdal;
+let assert;
+let destPath;
+
+if (isNode) assert = require('chai').assert;
+else assert = chai.assert;
+
+describe('function / clearFS', function () {
+    before(async function () {
+        if (isNode) {
+            this.timeout(15000);
+            destPath = require('fs').mkdtempSync('/tmp/gdaljs');
+            const initGdalJs = require('../../../build/package/gdal3.coverage');
+            Gdal = await initGdalJs({ path: 'build/package', dest: destPath });
+        } else {
+            this.timeout(30000);
+            Gdal = await initGdalJs({ path: '../package', useWorker: false });
+        }
+    });
+
+    it('cleans /output after conversion', async function () {
+        let file = 'data/polygon-line-point.geojson';
+        if (!isNode) {
+            const fileData = await fetch(file);
+            file = new File([await fileData.blob()], 'polygon-line-point.geojson');
+        } else file = `test/${file}`;
+
+        const result = await Gdal.open(file);
+        const dataset = result.datasets[0];
+        assert.strictEqual(dataset.pointer > 0, true, 'An error occurred while opening the geojson file. (ptr == 0)');
+
+        const output = await Gdal.ogr2ogr(dataset, ['-f', 'GeoJSON']);
+        await Gdal.close(dataset);
+
+        if (isNode) {
+            // With config.dest set, output goes to real disk via NODEFS.
+            // clearFS must not delete real files.
+            const fs = require('fs');
+            assert.isTrue(fs.existsSync(output.real), 'output file should exist on disk before clearFS');
+
+            await Gdal.clearFS();
+
+            assert.isTrue(fs.existsSync(output.real), 'real output file should remain after clearFS (NODEFS is not cleaned)');
+        } else {
+            const filesBefore = await Gdal.getOutputFiles();
+            assert.isAbove(filesBefore.length, 0, 'output should have files before clearFS');
+
+            await Gdal.clearFS();
+
+            const filesAfter = await Gdal.getOutputFiles();
+            assert.strictEqual(filesAfter.length, 0, 'output should be empty after clearFS');
+        }
+    });
+
+    it('cleans /input after conversion (browser only)', async function () {
+        if (isNode) {
+            // /input is always NODEFS on Node.js — clearFS intentionally skips it
+            this.skip();
+            return;
+        }
+
+        const fileData = await fetch('data/polygon.geojson');
+        const file = new File([await fileData.blob()], 'polygon.geojson');
+
+        const openResult = await Gdal.open(file);
+        assert.isAbove(openResult.datasets.length, 0, 'file should open successfully before clearFS');
+        await Gdal.close(openResult.datasets[0]);
+
+        await Gdal.clearFS();
+
+        // After clearFS the file must no longer be accessible in /input
+        try {
+            const reopenResult = await Gdal.open('/input/polygon.geojson');
+            assert.strictEqual(reopenResult.datasets.length, 0, '/input should be empty after clearFS');
+        } catch (errors) {
+            // open() rejects when all files fail — also proves the file was removed
+            assert.isAbove(errors.length, 0, 'open should fail for a cleaned /input file');
+        }
+    });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -61,6 +61,7 @@ interface Gdal {
     ogrinfo(dataset: Dataset, options?: Array<string>): Promise<object>;
     open(fileOrFiles: FileList|File|Array<string>|string, options?: Array<string>, VFSHandlers?: Array<string>): Promise<DatasetList>;
     close(dataset: Dataset): Promise<void>;
+    clearFS(): Promise<void>;
     getInfo(dataset: Dataset): Promise<DatasetInfo>;
     getOutputFiles(): Promise<Array<FileInfo>>;
     getFileBytes(filePath: string|FilePath): Promise<Uint8Array>;


### PR DESCRIPTION
Hi!
During my work, I came across a situation where I really needed functionality similar to that requested in #90, so I added it as a separate method.
This function clears not only the /output folder, but /input as well (when used in a browser without a webworker).